### PR TITLE
Configure Guardfile to enable live preview in browser

### DIFF
--- a/Guardfile
+++ b/Guardfile
@@ -1,0 +1,64 @@
+# A sample Guardfile
+# More info at https://github.com/guard/guard#readme
+
+## Uncomment and set this to only include directories you want to watch
+# directories %w(app lib config test spec feature)
+
+## Uncomment to clear the screen before every task
+# clearing :on
+
+## Guard internally checks for changes in the Guardfile and exits.
+## If you want Guard to automatically start up again, run guard in a
+## shell loop, e.g.:
+##
+##  $ while bundle exec guard; do echo "Restarting Guard..."; done
+##
+## Note: if you are using the `directories` clause above and you are not
+## watching the project directory ('.'), the you will want to move the Guardfile
+## to a watched dir and symlink it back, e.g.
+#
+#  $ mkdir config
+#  $ mv Guardfile config/
+#  $ ln -s config/Guardfile .
+#
+# and, you'll have to watch "config/Guardfile" instead of "Guardfile"
+
+# Add files and commands to this file, like the example:
+#   watch(%r{file/path}) { `command(s)` }
+#
+require 'asciidoctor'
+require 'erb'
+
+# The method used below extracts the relevant command from Makefile
+#
+# For example:
+#    `eval $( grep index.adoc Makefile )`
+#
+# Evaluates to:
+#    `asciidoctor -o dist/index.html index.adoc`
+#
+# The dependency on Makefile can be removed by using the command literally
+# However, every change in every line from Makefile would need to be duplicated here
+# With this dependency method, only new lines will need to be included in this file
+#
+guard :shell do
+  watch(/^index\.adoc$/) {
+    `eval $( grep index.adoc Makefile )`
+  }
+
+  watch(/^setup-production\.adoc$/) {
+    `eval $( grep setup-production.adoc Makefile )`
+  }
+
+  watch(/^setup-alternatives\.adoc$/) {
+    `eval $( grep setup-alternatives.adoc Makefile )`
+  }
+
+  watch(%r{^api/.+\.adoc}) {
+    `eval $( grep api.adoc Makefile )`
+  }
+
+  watch(/^webhooks\.adoc$/) {
+    `eval $( grep webhooks.adoc Makefile )`
+  }
+end

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,18 @@
+# Notes regarding keeping Makefile & Guardfile in sync
+# - Guardfile is configured to extract commands from this Makefile
+# - If decision is made to break this dependency, all commands from this
+#   Makefile should be duplicated in the Guardfile
+# - Thereafter, every single change will need to be applied in both files
+#
+# Guardfile *DOES require* modification if:
+# - A new .adoc file is added to this file
+# - The path/name of an existing .adoc file is changed
+#
+# Guardfile *DOES NOT require* modification if:
+# - Any other part of an existing command is changed, i.e.:
+#   - OK: Modifying asciidoctor command line switches
+#   - OK: Changing path/name for HTML output
+#
 all: doc
 doc:
 	asciidoctor -o dist/index.html index.adoc

--- a/README.md
+++ b/README.md
@@ -13,3 +13,61 @@ You can install Ruby through the apt package manager, pacman, rbenv, or rvm.
     $ gem install asciidoctor pygments.rb
     $ export PATH="~/.gem/ruby/2.1.0/bin:$PATH"
     $ asciidoctor -v // should return Asciidoctor 1.5.1 ...
+
+### (Optional) Setup live preview in browser
+
+> _Prerequisite: Initial environment above must be setup and working_
+
+#### Overview
+
+This step is optional but highly recommended in order to ease the process of editing AsciiDoc files, by rendering the HTML from the source `.adoc` file as soon as any modifications are saved - allowing for instant preview in the browser.
+
+The following instructions are based on the Asciidoctor page: [Editing AsciiDoc with Live Preview][1]
+
+#### Installation
+
+Install Guard and the shell file monitor:
+
+    $ gem install guard guard-shell rb-inotify
+
+#### Ensure Guard is working
+
+Confirm that `Guardfile` is in the base `taiga-doc` directory and then start Guard from that directory:
+
+    $ cd taiga-doc
+    $ guard start
+
+Open `index.adoc` in a text editor, make a minor modification and then save the file.
+If Guard is working properly, `dist/index.html` will be created/updated automatically.
+
+#### Configure live preview in the browser
+
+> _Note: The [Asciidoctor page][1] suggests using LiveReload with the `guard-livereload` gem but this package is [no longer compatible with LiveReload 2][2]_
+
+Simply use a browser that has auto-reload built-in or install a relevant browser add-on.
+
+Examples include:
+
+* [Web][3] web browser (formerly Epiphany web browser) - has built-in auto-reload functionality
+* Firefox + [Auto Reload][4] add-on
+* _[Please add other working configurations here]_
+
+#### Test live preview
+
+Open `dist/index.html` in the browser.
+As before, save a modification to `index.adoc`.
+Once Guard has rendered the new copy of `dist/index.html`, the browser will auto-reload the page.
+
+#### Working with live preview
+
+Some tips/notes about working with live preview:
+
+* Position the text editor and web browser windows side-by-side (or on different screens!), save changes and see the result in the browser almost immediately
+* Changes to any of the `.adoc` files within the `api/` directory or its sub-dirs will render `dist/api.html` - due to many `.adoc` files being combined to render the single HTML file, there is a slight lag in the live preview as the conversion process completes
+* Otherwise, there is a 1:1 relationship between the `.adoc` file and its rendered `.html` file - changes to these are displayed almost instantaneously
+
+
+[1]: http://asciidoctor.org/docs/editing-asciidoc-with-live-preview/
+[2]: http://feedback.livereload.com/knowledgebase/articles/86181-failed-to-start-port-occupied
+[3]: https://wiki.gnome.org/Apps/Web
+[4]: https://addons.mozilla.org/en-US/firefox/addon/auto-reload/


### PR DESCRIPTION
* Editing *.adoc files without live preview in the browser is tedious
* Guard is one of the recommended methods suggested for AsciiDoc:
http://asciidoctor.org/docs/editing-asciidoc-with-live-preview/
* This proposed Guardfile simply extracts the commands from the Makefile
and builds the html files as soon as one of the source adoc files has
been modified
* If this method is too "magical", can simply duplicate the lines from
the Makefile in the Guardfile instead
* Live preview is achieved when coupled with the other required
components

Follow-up to #25