### PR TITLE
Fix trailing commas in JSON

### DIFF
--- a/api/issue-statuses/create.adoc
+++ b/api/issue-statuses/create.adoc
@@ -17,7 +17,7 @@ curl -X POST \
         "is_closed": true,
         "name": "New status",
         "order": 8,
-        "project": 3,
+        "project": 3
     }' \
   https://api.taiga.io/api/v1/issue-statuses
 ----

--- a/api/issue-types/create.adoc
+++ b/api/issue-types/create.adoc
@@ -15,7 +15,7 @@ curl -X POST \
         "color": "#AAAAAA",
         "name": "New type",
         "order": 8,
-        "project": 3,
+        "project": 3
     }' \
   https://api.taiga.io/api/v1/issue-types
 ----

--- a/api/points/create.adoc
+++ b/api/points/create.adoc
@@ -17,7 +17,7 @@ curl -X POST \
         "name": "Huge",
         "order": 8,
         "value": 40,
-        "project": 3,
+        "project": 3
     }' \
   https://api.taiga.io/api/v1/points
 ----

--- a/api/priorities/create.adoc
+++ b/api/priorities/create.adoc
@@ -15,7 +15,7 @@ curl -X POST \
         "color": "#AAAAAA",
         "name": "New priority",
         "order": 8,
-        "project": 3,
+        "project": 3
     }' \
   https://api.taiga.io/api/v1/priorities
 ----

--- a/api/severities/create.adoc
+++ b/api/severities/create.adoc
@@ -15,7 +15,7 @@ curl -X POST \
         "color": "#AAAAAA",
         "name": "New severity",
         "order": 8,
-        "project": 3,
+        "project": 3
     }' \
   https://api.taiga.io/api/v1/severities
 ----

--- a/api/task-statuses/create.adoc
+++ b/api/task-statuses/create.adoc
@@ -17,7 +17,7 @@ curl -X POST \
         "is_closed": true,
         "name": "New status",
         "order": 8,
-        "project": 3,
+        "project": 3
     }' \
   https://api.taiga.io/api/v1/task-statuses
 ----

--- a/api/users/detail-response.adoc
+++ b/api/users/detail-response.adoc
@@ -13,6 +13,6 @@
     "id": 1,
     "is_active": true,
     "photo": "//www.gravatar.com/avatar/4648b6d514c3ecece1b87136ceeda1d1?size=80",
-    "username": "beta.tester",
+    "username": "beta.tester"
 }
 ----

--- a/api/users/password-recovery.adoc
+++ b/api/users/password-recovery.adoc
@@ -4,7 +4,7 @@ To request a user password recovery send a POST with the following data
 ----
 curl -X POST \
   -d '{
-          "username": "'${USERNAME_OR_EMAIL}'",
+          "username": "'${USERNAME_OR_EMAIL}'"
       }' \
   https://api.taiga.io/api/v1/users/password_recovery
 ----

--- a/api/wiki/create.adoc
+++ b/api/wiki/create.adoc
@@ -27,7 +27,7 @@ curl -X POST \
   -d '{
           "project": 1,
           "slug": "home",
-          "content": "Lorem ipsum dolor.",
+          "content": "Lorem ipsum dolor."
       }' \
   https://api.taiga.io/api/v1/wiki
 ----


### PR DESCRIPTION
### Resolution method
Found the problem when attempting to use `curl` example from 24.11.  Found and fixed the rest with a combination of `rgrep` + `perl`:
```
rgrep -Pzo -l ',([^\\]\s*}['\'']?)' api/ | xargs perl -0777 -pe 's:,([^\\]\s*}['\'']?):$1:g' -i
```

### Future prevention using `build-docs.sh`
* Could use the `rgrep` part above in `build-docs.sh` to at least issue a warning when building the docs
* Could take this one step further and offer to automatically fix it
* Or could just fix things silently without warning or prompting (I don't think this is a good idea)