### PR TITLE
Notify re: JSON trailing commas using new Guardfile, Guard run through b...

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,8 @@
+group :development do
+  gem 'asciidoctor'
+  gem 'pygments.rb'
+  gem 'guard'
+  gem 'guard-shell'
+  gem 'rb-inotify'
+  gem 'libnotify'
+end

--- a/Guardfile
+++ b/Guardfile
@@ -29,40 +29,52 @@
 require 'asciidoctor'
 require 'erb'
 
+# This Guardfile currently has dependencies on 2 other files:
+# 1. Makefile
+# 2. tests/check_JSON_trailing_commas.sh
+#
 # The method used below extracts the relevant command from Makefile
 #
-# For example:
-#    `eval $( grep index.adoc Makefile )`
+# For example (where filename=index.adoc):
+#    `eval "$( grep "#{filename}" Makefile )"`
 #
 # Evaluates to:
 #    `asciidoctor -o dist/index.html index.adoc`
 #
 # The dependency on Makefile can be removed by using the command literally
 # However, every change in every line from Makefile would need to be duplicated here
-# With this dependency method, only new lines will need to be included in this file
+# With this dependency method, there are very few circumstances where any changes
+#   need to be made to this file (see Makefile comments for examples)
 #
 guard :shell do
-  watch(/^index\.adoc$/) {
-    `eval $( grep index.adoc Makefile )`
-  }
+  watch(%r{^.+\.adoc}) { |m|
+    # Check modified file for JSON trailing commas
+    if not system("tests/check_JSON_trailing_commas.sh #{m[0]}")
+      n "[#{m[0]}] has at least one suspected JSON trailing comma",
+	"Check for JSON trailing comma [#{m[0]}] has failed",
+	:pending
+    end
 
-  watch(/^setup-production\.adoc$/) {
-    `eval $( grep setup-production.adoc Makefile )`
-  }
+    # Determine which filename to use when searching for the render command in Makefile
+    if "#{m[0][0,4]}"=="api/"
+      filename="api/api.adoc"
+    else
+      filename="#{m[0]}"
+    end
 
-  watch(/^setup-development\.adoc$/) {
-    `eval $( grep setup-development.adoc Makefile )`
-  }
-
-  watch(/^setup-alternatives\.adoc$/) {
-    `eval $( grep setup-alternatives.adoc Makefile )`
-  }
-
-  watch(%r{^api/.+\.adoc}) {
-    `eval $( grep api.adoc Makefile )`
-  }
-
-  watch(/^webhooks\.adoc$/) {
-    `eval $( grep webhooks.adoc Makefile )`
+    # Run the command to render the .adoc file if it is in Makefile
+    if system("grep #{filename} Makefile")
+      # Quotation marks are important since they allow running more than one matched command
+      `eval "$( grep "#{filename}" Makefile )"`
+      n "[#{filename}] has been found in Makefile and the relevant rendering " +
+	"command has been performed",
+	"[#{filename}] rendered via. Makefile",
+	:success
+    else
+      n "The command to render [#{filename}] has not been found in Makefile\n" +
+	"- please add it there so that rendering can be performed",
+	"[#{filename}] not found in Makefile",
+	:failed
+    end
   }
 end

--- a/Makefile
+++ b/Makefile
@@ -4,11 +4,22 @@
 #   Makefile should be duplicated in the Guardfile
 # - Thereafter, every single change will need to be applied in both files
 #
+# *DO NOT*:
+# - Write the whole path/name of one of the .adoc files in any comment
+#
+# M:1 vs. 1:1 .adoc files:
+# - 1:1 is where 1 .adoc file is rendered to 1 output file
+# - M:1 is where 1 .adoc file references many other .adoc files, but rendered
+#   to only 1 output file (such as api.adoc)
+#
 # Guardfile *DOES require* modification if:
-# - A new .adoc file is added to this file
-# - The path/name of an existing .adoc file is changed
+# - A new M:1 .adoc file is added to this file
+# - The path/name of an existing M:1 .adoc file is changed
 #
 # Guardfile *DOES NOT require* modification if:
+# - A new 1:1 .adoc file is added to this file
+# - The path/name of an existing 1:1 .adoc file is changed
+# - More than 1 command is used to render an existing .adoc file
 # - Any other part of an existing command is changed, i.e.:
 #   - OK: Modifying asciidoctor command line switches
 #   - OK: Changing path/name for HTML output

--- a/build-docs.sh
+++ b/build-docs.sh
@@ -1,5 +1,8 @@
 #!/bin/sh
 
+# Not exiting for the JSON trailing commas check since just a warning, not an error
+tests/check_JSON_trailing_commas.sh
+
 make || exit 1
 rm -rf /tmp/taiga-doc-dist || exit 1
 cp -r dist /tmp/taiga-doc-dist || exit 1

--- a/tests/check_JSON_trailing_commas.sh
+++ b/tests/check_JSON_trailing_commas.sh
@@ -1,0 +1,37 @@
+#!/bin/sh
+
+# This script is used in two ways:
+# 1. To check a single .adoc file as soon as it is modified (via. Guardfile)
+# 2. To check all of the .adoc files when the docs are being build (via. build-docs.sh)
+#
+INCLUDE_GLOB="*.adoc"
+
+if [ $# -eq 0 ]; then
+    CHECK_FILE="."
+else
+    CHECK_FILE="${1}"
+fi
+
+# REGEX     EXPLANATION
+# ,         Match the suspected JSON trailing comma
+# (...)     Bracket around the rest of the search string so that it can be used as the Perl replace string, $1 (not implemented, yet)
+# [^\\]     Match beginning of next line
+# \s*       Match 0 or more spaces from the beginning of the line
+# }         Match the JSON end brace
+# ['\'']?   Match the possible single quote here (has to be escaped due to the whole regex being enclosed in single quotes)
+# \s?       Match the possible space here
+# \\?       Match the possible backslash here
+# $         Match end of line
+#
+CHECK_JSON=$( rgrep -Pzo -l --include="${INCLUDE_GLOB}" ',([^\\]\s*}['\'']?\s?\\?$)' "${CHECK_FILE}" )
+if [ -z "${CHECK_JSON}" ]; then
+    exit 0
+else
+    echo "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
+    echo "WARNING: (${INCLUDE_GLOB}) file(s) with suspected JSON trailing commas"
+    echo "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
+    echo "${CHECK_JSON}"
+    echo "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
+    echo
+    exit 1
+fi

--- a/tests/exclude-from_check_JSON_trailing_commas
+++ b/tests/exclude-from_check_JSON_trailing_commas
@@ -1,0 +1,12 @@
+# Purpose:
+# - list of files to ignore when checking for JSON trailing commas
+# - particular use case is to ignore false-positives
+# - excludes files by base name only (not full or relative path)
+# - DO NOT precede the listed files with a space or they will not be excluded
+# - 1 file per line
+#
+# Examples:
+# - Uncomment the following examples to exclude them from being tested
+#
+#webhooks.adoc
+#normal-login.adoc


### PR DESCRIPTION
...undle

* Overview: Using Guard to run test and show notifications
* Need to install Guard according to official instructions from:
  https://github.com/guard/guard#readme:
  "It's important that you always run Guard through Bundler to avoid errors."
* New script to perform check for JSON trailing commas; used in 2 ways:
  1. Guard => file just modified
  2. build-docs.sh => check all .adoc files in taiga-doc (warnings, no exit)
* Guardfile improvements:
  - Works with new .adoc files automatically
  - Notifies user where a match in Makefile is not found
  - Works with multiple line matches in Makefile
  - Centralised into 1 watch so much easier to add more tests or make changes

### Next steps
@jespino @superalex 
* If following through with this PR, README.md needs to be updated with the new `bundle`-based instructions
* Will put a rough version of them in the next comment, so that you guys can test these changes and have notifications running
* If you're happy, then I can finalise