### PR TITLE
Update README re: JSON trailing comma notification and fix webhooks.adoc

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,11 +6,15 @@ Web: http://taigaio.github.io/taiga-doc/dist/
 
 ### Setup initial environment (for developers)
 
-Install requirements: Ruby / asciidoctor + pygments.rb
+Install requirements: Ruby / `asciidoctor` + `pygments.rb` (installed via. `bundler` using the provided `Gemfile`)
 
-You can install Ruby through the apt package manager, pacman, rbenv, or rvm. 
+You can install Ruby through the apt package manager, pacman, rbenv, or rvm.
 
-    $ gem install asciidoctor pygments.rb
+Confirm that `Gemfile` is in the base `taiga-doc` directory and then perform the installation from that directory:
+
+    $ cd taiga-doc
+    $ gem install bundler
+    $ bundle
     $ export PATH="~/.gem/ruby/2.1.0/bin:$PATH"
     $ asciidoctor -v // should return Asciidoctor 1.5.1 ...
 
@@ -22,23 +26,37 @@ You can install Ruby through the apt package manager, pacman, rbenv, or rvm.
 
 This step is optional but highly recommended in order to ease the process of editing AsciiDoc files, by rendering the HTML from the source `.adoc` file as soon as any modifications are saved - allowing for instant preview in the browser.
 
-The following instructions are based on the Asciidoctor page: [Editing AsciiDoc with Live Preview][1]
+The following instructions are based on:
+* The Asciidoctor page: [Editing AsciiDoc with Live Preview][1]
+* The Guard README: [Guard: README.md][5]
 
 #### Installation
 
-Install Guard and the shell file monitor:
+If the `bundler` install completed successfully, all of the gems will already be in place (including both Guard and the shell file monitor).
 
-    $ gem install guard guard-shell rb-inotify
+For notifications to work properly:
+> You have to install the libnotify-bin package with your favorite package manager
+>
+> -- [Guard: System notifications - Libnotify][6]
+
+For example, on a Debian-based system:
+
+    $ sudo apt-get install libnotify-bin
 
 #### Ensure Guard is working
+
+> It's important that you always run Guard through Bundler to avoid errors.
+>
+> -- [Guard: README.md][5]
 
 Confirm that `Guardfile` is in the base `taiga-doc` directory and then start Guard from that directory:
 
     $ cd taiga-doc
-    $ guard start
+    $ bundle exec guard
 
-Open `index.adoc` in a text editor, make a minor modification and then save the file.
-If Guard is working properly, `dist/index.html` will be created/updated automatically.
+* Open `index.adoc` in a text editor, make a minor modification and then save the file
+* If Guard is working properly, `dist/index.html` will be created/updated automatically
+* If `libnotify` is configured correctly, a notification will be shown confirming that `index.adoc` has been found and rendered accordingly
 
 #### Configure live preview in the browser
 
@@ -54,16 +72,16 @@ Examples include:
 
 #### Test live preview
 
-Open `dist/index.html` in the browser.
-As before, save a modification to `index.adoc`.
-Once Guard has rendered the new copy of `dist/index.html`, the browser will auto-reload the page.
+* Open `dist/index.html` in the browser
+* As before, save a modification to `index.adoc`
+* Once Guard has rendered the new copy of `dist/index.html`, the browser will auto-reload the page
 
 #### Working with live preview
 
 Some tips/notes about working with live preview:
 
 * Position the text editor and web browser windows side-by-side (or on different screens!), save changes and see the result in the browser almost immediately
-* Changes to any of the `.adoc` files within the `api/` directory or its sub-dirs will render `dist/api.html` - due to many `.adoc` files being combined to render the single HTML file, there is a slight lag in the live preview as the conversion process completes
+* Changes to any of the `.adoc` files within the `api/` directory or its sub-dirs will render `dist/api.html` - since many `.adoc` files are combined to render the single HTML file, there is a slight lag in the live preview as the conversion process completes
 * Otherwise, there is a 1:1 relationship between the `.adoc` file and its rendered `.html` file - changes to these are displayed almost instantaneously
 
 
@@ -71,3 +89,5 @@ Some tips/notes about working with live preview:
 [2]: http://feedback.livereload.com/knowledgebase/articles/86181-failed-to-start-port-occupied
 [3]: https://wiki.gnome.org/Apps/Web
 [4]: https://addons.mozilla.org/en-US/firefox/addon/auto-reload/
+[5]: https://github.com/guard/guard#guard
+[6]: https://github.com/guard/guard/wiki/System-notifications#libnotify

--- a/webhooks.adoc
+++ b/webhooks.adoc
@@ -81,7 +81,7 @@ Test payload
 {
     "data": {"test": "test"},
     "action": "test",
-    "type": "test",
+    "type": "test"
 }
 ----
 


### PR DESCRIPTION
@jespino: Here is the update.  Some notes:

* Fixed the stray comma in `webhooks.adoc`
* I've merged the instructions with the first section **Setup initial environment (for developers)** to minimise duplication of effort - however, you guys might not like that so we can move the `bundler` installation lower down
* Follow-up to #31 & #32 