### PR TITLE
Update setup-production.adoc

### DIFF
--- a/setup-production.adoc
+++ b/setup-production.adoc
@@ -37,6 +37,7 @@ We assume the following:
 - **ip:** `80.88.23.45`
 - **hostname:** `example.com` (which points to 80.88.23.45)
 - **username:** `taiga`
+- **system ram** `>=1GB` (needed for compilation of lxml)
 
 
 Backend installation


### PR DESCRIPTION
The minimum system ram for the compilation of lxml is > 512MB. e.g. small digitalocean droplets fail to compile this dependency with internal gcc compiler errors. With at least 1GB of ram for the installation process this can be avoided.