### PR TITLE
Update bulk-create.adoc

### DIFF
--- a/api/tasks/bulk-create.adoc
+++ b/api/tasks/bulk-create.adoc
@@ -2,6 +2,8 @@ To create multiple tasks at the same time send a POST request with the following
 
 - *project_id* (required)
 - *status_id*
+- *sprint_id*: milestone id (optional)
+- *us_id*: user story id (optional)
 - *bulk_tasks*: task subjects, one per line
 
 


### PR DESCRIPTION
According to https://github.com/taigaio/taiga-back/blob/master/taiga/projects/tasks/api.py#L136
sprint_id and us_id fields are also available.