### PR TITLE
Let API auth example handle escape characters

### DIFF
--- a/api/general-notes.adoc
+++ b/api/general-notes.adoc
@@ -37,16 +37,17 @@ $ sudo apt-get install jq
 #!/bin/bash
 # Request username and password for connecting to Taiga
 read -p "Username or email: " USERNAME
-read -s -p "Password: " PASSWORD
+read -r -s -p "Password: " PASSWORD
+
+DATA=$(jq --null-input \
+        --arg username "$USERNAME" \
+        --arg password "$PASSWORD" \
+        '{ type: "normal", username: $username, password: $password }')
 
 # Get AUTH_TOKEN
 USER_AUTH_DETAIL=$( curl -X POST \
   -H "Content-Type: application/json" \
-  -d '{
-          "type": "normal",
-          "username": "'${USERNAME}'",
-          "password": "'${PASSWORD}'"
-      }' \
+  -d "$DATA" \
   https://api.taiga.io/api/v1/auth 2>/dev/null )
 
 AUTH_TOKEN=$( echo ${USER_AUTH_DETAIL} | jq -r '.auth_token' )


### PR DESCRIPTION
This enables support for passwords containing character sequences that
could be considered escape characters, such as for example '\a'.

I do not know how to deal with escape characters when jq isn't available as I don't know escaping rules of JSON by hart.