### PR TITLE
Edit layout - open menu

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -29,5 +29,15 @@ ul,ol,dl{margin-bottom:0em;}
 #toc.toc2{background:none;border-right:none;}
 #toc{width:15em !important;border-bottom:none !important;}
 body {padding-left:0px !important;}
-#toc.toc2{left:-15em}
+#toc.toc2{left:-30em}
 .scroller,.scroller-inner {position: relative;}
+
+.scroller {
+	width: calc(100% - 240px);
+}
+.mp-cover {
+	transform: translate3d(240px, 0, 0);
+}
+#trigger {
+	display: none;
+}

--- a/assets/css/menu.css
+++ b/assets/css/menu.css
@@ -104,6 +104,7 @@ html, body, .container, .scroller {
 	opacity: 1;
 	-webkit-transition: opacity 0.3s;
 	transition: opacity 0.3s;
+	display: none;
 }
 
 .mp-level.mp-level-overlay {

--- a/assets/js/mlpushmenu.js
+++ b/assets/js/mlpushmenu.js
@@ -103,6 +103,7 @@
 		},
 		_initEvents : function() {
 			var self = this;
+			self._openMenu();
 
 			// the menu should close if clicking somewhere on the body
 			var bodyClickFn = function( el ) {
@@ -120,11 +121,11 @@
 				else {
 					self._openMenu();
 					// the menu should close if clicking somewhere on the body (excluding clicks on the menu)
-					document.addEventListener( self.eventtype, function( ev ) {
+					/*document.addEventListener( self.eventtype, function( ev ) {
 						if( self.open && !hasParent( ev.target, self.el.id ) ) {
 							bodyClickFn( this );
 						}
-					} );
+					} );*/
 				}
 			} );
 


### PR DESCRIPTION
![screencapture-file-c-users-user-taiga-doc-assets-index-html-1464915148325](https://cloud.githubusercontent.com/assets/6073063/15765565/bcf44e4a-2968-11e6-99c4-e6bee7addab4.png)

After some tryouts I find it too difficult for me to amend the layout to one with a menu opened by default with a trigger. Given the template by Codrops, it seems to me that it has to deal with certain core functionalities, which are beyond the edits on layout structure, CSS and simple JS fixes I did when I implemented the template.

To keep the trigger, at least there would be a number of rules dealing with position and transform needed to be fixed, and it is very likely that the logic related to opening/closing the menu has to be amended.

So I tried my best so far to implement:
Menu opened by default (It's using the "open menu" function in the javascript, so there is the animation when it's initialized, otherwise I don't know how to achieve this without changing core logic in the javascript.)

Known issues:
Animation when the menu is initialized as if the button is clicked in the current version.
In the API page, the menu is scrolled to top when a new layer is opened to display it properly (This issue is inherited from the current version).

Ref: https://groups.google.com/forum/#!topic/taigaio/WruyPJUdnYE
