### PR TITLE
Added -y option in apt-get command

### DIFF
--- a/setup-production.adoc
+++ b/setup-production.adoc
@@ -89,7 +89,7 @@ libraries. As a first step, start installing python and virtualenvwrapper:
 [source,bash]
 ----
 sudo apt-get install -y python3 python3-pip python-dev python3-dev python-pip virtualenvwrapper
-sudo apt-get install libxml2-dev libxslt-dev
+sudo apt-get install -y libxml2-dev libxslt-dev
 ----
 
 [NOTE]


### PR DESCRIPTION
Seems to be a missing -y option in 
`sudo apt-get install libxml2-dev libxslt-dev`

Not sure if this is intentional, it's just a glaring difference compared to the previous apt-get instructions.