### PR TITLE
Update scss lint doc

### DIFF
--- a/setup-development.adoc
+++ b/setup-development.adoc
@@ -243,7 +243,7 @@ sudo apt-get install -y ruby
 .Install required gems
 [source,bash]
 ----
-gem install --user-install sass scss-lint
+gem install --user-install sass scss_lint
 ----
 
 .Make gems' scripts available from your path by putting this in your *~/.bashrc*


### PR DESCRIPTION
According to the documentation on [scss-lint](https://github.com/brigade/scss-lint#installation)
The current documentation is not working for my ubuntu.