### PR TITLE
libssl-dev libffi-dev to Prerequisites because of Python Cryptography package

### DIFF
--- a/setup-production.adoc
+++ b/setup-production.adoc
@@ -90,6 +90,7 @@ sudo apt-get install -y postgresql-doc-9.5 postgresql-server-dev-9.5
 ----
 sudo apt-get install -y python3 python3-pip python-dev python3-dev python-pip virtualenvwrapper
 sudo apt-get install -y libxml2-dev libxslt-dev
+sudo apt-get install -y libssl-dev libffi-dev
 ----
 
 [NOTE]


### PR DESCRIPTION
On multiple occasions, the `pip install -r requirements.txt` command failed because the Python Cryptography package could not be built and threw errors like: 
> fatal error: openssl/opensslv.h: No such file or directory

This is because of missing libssl-dev and libffi-dev packages.
I highly suggest adding it to the prerequisites field because this can be a common issue.

Cheers
/theriverman