### PR TITLE
I had to install libssl-dev in addition

### DIFF
--- a/setup-development.adoc
+++ b/setup-development.adoc
@@ -41,7 +41,7 @@ C compiler and development headers.
 ----
 sudo apt-get install -y build-essential binutils-doc autoconf flex bison libjpeg-dev
 sudo apt-get install -y libfreetype6-dev zlib1g-dev libzmq3-dev libgdbm-dev libncurses5-dev
-sudo apt-get install -y automake libtool libffi-dev curl git tmux gettext
+sudo apt-get install -y automake libtool libffi-dev libssl-dev curl git tmux gettext
 ----
 
 Setup a database


### PR DESCRIPTION
```
    x86_64-linux-gnu-gcc -pthread -DNDEBUG -g -fwrapv -O2 -Wall -Wstrict-prototypes -g -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2 -fPIC -I/usr/include/python3.5m -I/home/john/repos/git/taiga-back/include/python3.5m -c build/temp.linux-x86_64-3.5/_openssl.c -o build/temp.linux-x86_64-3.5/build/temp.linux-x86_64-3.5/_openssl.o
    build/temp.linux-x86_64-3.5/_openssl.c:493:30: fatal error: openssl/opensslv.h: No such file or directory
    compilation terminated.
    error: command 'x86_64-linux-gnu-gcc' failed with exit status 1
```

After installing `libssl-dev`, `pip install -r requirements-devel.txt` completes successfully.