### PR TITLE
Install `ruby-dev` as dependency

### DIFF
--- a/setup-development.adoc
+++ b/setup-development.adoc
@@ -234,7 +234,7 @@ is only in development environments.
 .Install ruby
 [source,bash]
 ----
-sudo apt-get install -y ruby
+sudo apt-get install -y ruby ruby-dev
 ----
 
 .Install required gems


### PR DESCRIPTION
In section 4.1.1:  we also need the `ruby-dev` package as a dependency to install required gems