### PR TITLE
doc(docker-installation): #4445 warning to clarify localhost access

### DIFF
--- a/setup-production.adoc
+++ b/setup-production.adoc
@@ -384,7 +384,7 @@ Once everything has been installed, launch all the services and check the result
 $ docker-compose up -d
 ----
 
-Go to `http://localhost:9000` and check your Taiga Platform is available.
+If you're testing it in your own machine, you can access your Taiga Platform in **http://localhost:9000**. If you're deploying in a server, you'll need to configure hosts and nginx as described later.
 
 === Configure the proxy
 


### PR DESCRIPTION
Includes a warning in the docker installation guide, to clarify the default localhost:9000 access.
- Original issue https://github.com/taigaio/taiga-docker/issues/69
- Taiga's issue: https://tree.taiga.io/project/taiga/issue/4445

> **WARNING**: This PR should be merged in conjunction with:
https://github.com/kaleidos-ventures/taiga-docker/pull/1
https://github.com/kaleidos-ventures/taiga-resources/pull/1

![gif](https://media.giphy.com/media/lOgzjLU2mmN3VoUG4S/giphy.gif)

