### PR TITLE
chore(docs): reflect changes to use env variables in doker-compose

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ## 6.6.0 (Unreleased)
 
-- ...
+- New .env based guide and migration guide
+- Fix a compiling issue
 
 ## 6.5.0 (2022-01-24)
 

--- a/Gemfile
+++ b/Gemfile
@@ -9,5 +9,5 @@ group :development do
   gem 'rb-inotify'
   gem 'libnotify'
   gem 'thread_safe'
-  gem 'haml'
+  gem 'haml', '~>5.2.1'
 end

--- a/Makefile
+++ b/Makefile
@@ -29,9 +29,11 @@ all: doc
 doc:
 	asciidoctor -T custom-html5 -o dist/index.html index.adoc
 	asciidoctor -T custom-html5 -o dist/setup-production.html setup-production.adoc
+	asciidoctor -T custom-html5 -o dist/setup-production.old.html setup-production.old.adoc
 	asciidoctor -T custom-html5 -o dist/setup-development.html setup-development.adoc
 	asciidoctor -T custom-html5 -o dist/setup-faqs.html setup-faqs.adoc
 	asciidoctor -T custom-html5 -o dist/upgrades-6to6.html upgrades-6to6.adoc
+	asciidoctor -T custom-html5 -o dist/upgrades-docker-migrate.html upgrades-docker-migrate.adoc
 	asciidoctor -T custom-html5 -o dist/upgrades-older.html upgrades-older.adoc
 	asciidoctor -T custom-html5 -o dist/upgrades-5to6.html upgrades-5to6.adoc
 	asciidoctor -T custom-html5 -o dist/api.html api/api.adoc
@@ -51,9 +53,11 @@ doc:
 pdf:
 	asciidoctor -a allow-uri-read -r asciidoctor-pdf -b pdf -o dist/pdfs/index.pdf index.adoc
 	asciidoctor -a allow-uri-read -r asciidoctor-pdf -b pdf -o dist/pdfs/setup-production.pdf setup-production.adoc
+	asciidoctor -a allow-uri-read -r asciidoctor-pdf -b pdf -o dist/pdfs/setup-production.old.pdf setup-production.old.adoc
 	asciidoctor -a allow-uri-read -r asciidoctor-pdf -b pdf -o dist/pdfs/setup-development.pdf setup-development.adoc
 	asciidoctor -a allow-uri-read -r asciidoctor-pdf -b pdf -o dist/pdfs/setup-faqs.pdf setup-faqs.adoc
 	asciidoctor -a allow-uri-read -r asciidoctor-pdf -b pdf -o dist/pdfs/upgrades-6to6.html upgrades-6to6.adoc
+	asciidoctor -a allow-uri-read -r asciidoctor-pdf -b pdf -o dist/pdfs/upgrades-docker-migrate.html upgrades-docker-migrate.adoc
 	asciidoctor -a allow-uri-read -r asciidoctor-pdf -b pdf -o dist/pdfs/upgrades-older.html upgrades-older.adoc
 	asciidoctor -a allow-uri-read -r asciidoctor-pdf -b pdf -o dist/pdfs/upgrades-5to6.html upgrades-5to6.adoc
 	asciidoctor -a allow-uri-read -r asciidoctor-pdf -b pdf -o dist/pdfs/api/api.pdf api/api.adoc

--- a/index.adoc
+++ b/index.adoc
@@ -1,6 +1,7 @@
 = Taiga Documentation
 :toc: left
 :toclevels: 1
+:icons: font
 
 Free. Open Source. Powerful. _Taiga_ is a project management platform for startups
 and agile developers & designers who want a simple, beautiful tool that makes work
@@ -17,13 +18,17 @@ This section details everything you need to know to get _Taiga_ up and running i
 
 === Setup Production Environment with Docker [Recommended]
 
-link:setup-production.html#setup-prod-with-docker[This document contains the complete tutorial for installation with docker] of how
-to properly setup _Taiga_ for a low traffic production environment.
+link:setup-production.html#setup-prod-with-docker[This document contains the complete tutorial for installation with docker] of how to properly setup _Taiga_ for a low traffic production environment.
+
+[NOTE]
+.Previous installation guide
+====
+You can access the link:setup-production.old.html#setup-prod-with-docker-old[older docker installation guide] for documentation purposes, intended just for earlier versions of Taiga (prior to ver. 6.6.0)
+====
 
 === Setup Production Environment from Source Code
 
-link:setup-production.html#setup-prod-from-source-code[This document contains the complete, step by step tutorial] of how
-to properly setup _Taiga_ for a low traffic production environment.
+link:setup-production.html#setup-prod-from-source-code[This document contains the complete, step by step tutorial] of how to properly setup _Taiga_ for a low traffic production environment.
 
 === Setup FAQs and common Bugs
 
@@ -32,13 +37,15 @@ You can view a list of common FAQs and bugs related to the setup process link:se
 [[upgrading-guide]]
 == Upgrading Guide
 
-This section explains how to upgrade your current Taiga to a newer version
+This section links different upgrade methods depending on your Taiga:
 
-=== Upgrade Taiga6 docker
+=== [Docker] Upgrade Taiga6
 
 This section shows how to keep your link:upgrades-6to6.html[taiga-docker instance up to date] with the new releases.
 
-=== Upgrade from Taiga5 to Taiga6
+**Recommended** If you're already using taiga-docker, follow this link:upgrades-docker-migrate.html[migration guide] to use the new `.env` based deployment.
+
+=== [Source code] Upgrade from Taiga5 to Taiga6
 
 Update your link:upgrades-5to6.html[Taiga5 instance to a new Taiga6 version].
 This section covers different upgrade scenarios:
@@ -47,7 +54,7 @@ This section covers different upgrade scenarios:
 - from Taiga5 in docker to Taiga6 in docker
 - from Taiga5 source code to Taiga6 source code
 
-=== Older versions
+=== [Source code] Older versions
 
 Update between link:upgrades-older.html[versions].
 

--- a/setup-production.adoc
+++ b/setup-production.adoc
@@ -4,6 +4,7 @@
 :numbered:
 :source-highlighter: pygments
 :pygments-style: friendly
+:icons: font
 
 [[setup-prod-with-docker]]
 == Docker
@@ -12,6 +13,12 @@ This is the easiest and *recommended* way to run Taiga in production.
 This document explains how to deploy a full Taiga service for a production environment with `docker`.
 
 **Note** If you're updating from serving taiga6 in subdomain to subpath, check the specific instructions at the end of this tutorial.
+
+[NOTE]
+.Previous installation guide
+====
+You can access the link:setup-production.old.html#setup-prod-with-docker-old[older docker installation guide] for documentation purposes, intended just for earlier versions of Taiga (prior to ver. 6.6.0)
+====
 
 === Requirements
 
@@ -31,101 +38,130 @@ $ cd taiga-docker/
 $ git checkout stable
 ----
 
-=== Configuration and Customisation with Environment Variables
-
-This configuration is likely to suit what you need. Edit environment variables in `docker-compose.yml` and `docker-compose-inits.yml`. Have in mind that some of the variables are in both files, and you need to edit both.
-
-**Configuration** variables are in `docker-compose.yml` with default values that we strongly recommend that you change or review. Those variables are needed to run Taiga. Apart from this configuration, you can have some **customisation** in Taiga, that add features which are disabled by default. Find those variables in **Customisation** section and add the corresponding environment variables whenever you want to enable them.
-
 === Configuration
 
-.Database configuration
+We've exposed the ** Basic configuration ** settings in Taiga to an `.env` file. We strongly recommend you to change it, or at least review its content, to avoid using the default values.
 
-These vars will be used to create the database for Taiga and connect to it.
+Both `docker-compose.yml` and `docker-compose-inits.yml` will read from this file to populate their environment variables, so, initially you don't need to change them. Edit these files just in case you require to enable **Additional customization**, or an **Advanced configuration**.
 
-**Important**: these vars should have the same values in `taiga-back` and `taiga-db`.
+Refer to these sections for further information.
 
-**Service: taiga-db**
+=== Basic Configuration
+
+You will find basic **configuration variables** in the `.env` file. As stated before, we encourage you to edit these values, especially those affecting the security.
+
+.**Database settings**
+
+These vars are used to create the database for Taiga and connect to it.
+
 [source, bash]
 ----
-POSTGRES_DB: taiga
-POSTGRES_USER: taiga
-POSTGRES_PASSWORD: taiga
+POSTGRES_USER=taiga  # user to connect to PostgreSQL
+POSTGRES_PASSWORD=taiga  # database user's password
 ----
 
-**Service: taiga-back**
+.**URLs settings**
+
+These vars set where your Taiga instance should be served, and the security protocols to use in the communication layer.
 [source, bash]
 ----
-POSTGRES_DB: taiga
-POSTGRES_USER: taiga
-POSTGRES_PASSWORD: taiga
+TAIGA_SCHEME=http  # serve Taiga using "http" or "https" (secured) connection
+TAIGA_DOMAIN=localhost:9000  # Taiga's base URL
+SUBPATH=""  # it'll be appended to the TAIGA_DOMAIN (use either "" or a "/subpath")
+WEBSOCKETS_SCHEME=ws  # events connection protocol (use either "ws" or "wss")
 ----
 
-Additionally, you can also configure `POSTGRES_PORT` in `taiga-back`. Defaults to '5432'.
-
-.Taiga Settings
-
-**Service: taiga-back**
-
-The default configuration assumes Taiga is being served in a **subdomain**:
+The default configuration assumes Taiga is being served in a **subdomain**. For example:
 [source, bash]
 ----
-TAIGA_SECRET_KEY: "taiga-back-secret-key"
-TAIGA_SITES_SCHEME: "https"
-TAIGA_SITES_DOMAIN: "taiga.mycompany.com"
-TAIGA_SUBPATH: ""
+TAIGA_SCHEME=https
+TAIGA_DOMAIN=taiga.mycompany.com
+SUBPATH=""
+WEBSOCKETS_SCHEME=wss
 ----
 
-If Taiga is being served in a **subpath** instead of a subdomain, the configuration should be something like:
+If Taiga is being served in a **subpath**, instead of a subdomain, the configuration should be something like this:
 [source, bash]
 ----
-TAIGA_SECRET_KEY: "taiga-back-secret-key"
-TAIGA_SITES_SCHEME: "https"
-TAIGA_SITES_DOMAIN: "mycompany.com"
-TAIGA_SUBPATH: "/taiga"
+TAIGA_SCHEME=https
+TAIGA_DOMAIN=mycompany.com
+SUBPATH="/taiga"
+WEBSOCKETS_SCHEME=wss
 ----
 
-In this case, it's necessary to do some configurations in `taiga-front` as well.
+.**Secret Key settings**
 
-**Service: taiga-front**
+This variable allows you to set the secret key in Taiga, used in the cryptographic signing.
 
-The default configuration assumes Taiga is being served in a **subdomain**:
 [source, bash]
 ----
-TAIGA_URL: "https://taiga.mycompany.com"
-TAIGA_WEBSOCKETS_URL: "wss://taiga.mycompany.com"
-TAIGA_SUBPATH: ""
+SECRET_KEY="taiga-secret-key"  # Please, change it to an unpredictable value!
 ----
 
-If Taiga is being served in a **subpath** instead of a subdomain, the configuration should be something like:
+.**Email settings**
+
+By default, emails will be printed in the standard output (`EMAIL_BACKEND=**console**`). If you have your own SMTP service, change it to `EMAIL_BACKEND=**smtp**` and configure the rest of these variables with the values supplied by your SMTP provider:
+
 [source, bash]
 ----
-TAIGA_URL: "https://mycompany.com"
-TAIGA_WEBSOCKETS_URL: "wss://mycompany.com"
-TAIGA_SUBPATH: "/taiga"
+EMAIL_BACKEND=console  # use an SMTP server or display the emails in the console (either "smtp" or "console")
+EMAIL_HOST=smtp.host.example.com  # SMTP server address
+EMAIL_PORT=587   # default SMTP port
+EMAIL_HOST_USER=user  # user to connect the SMTP server
+EMAIL_HOST_PASSWORD=password  # SMTP user's password
+EMAIL_DEFAULT_FROM=changeme@example.com  # email address for the automated emails
+
+# EMAIL_USE_TLS/EMAIL_USE_SSL are mutually exclusive (only set one of those to True)
+EMAIL_USE_TLS=True  # use TLS (secure) connection with the SMTP server
+EMAIL_USE_SSL=False  # use implicit TLS (secure) connection with the SMTP server
 ----
 
-**Service: taiga-events**
+.**Queue manager settings**
+These variables are used to leave messages in the rabbitmq services.
+
 [source, bash]
 ----
-TAIGA_SECRET_KEY: "taiga-back-secret-key"
+RABBITMQ_USER=taiga  # user to connect to RabbitMQ
+RABBITMQ_PASS=taiga  # RabbitMQ user's password
+RABBITMQ_VHOST=taiga  # RabbitMQ container name
+RABBITMQ_ERLANG_COOKIE=secret-erlang-cookie  # unique value shared by any connected instance of RabbitMQ
 ----
 
-**Service: taiga-protected**
+
+.**Attachments settings**
+
+You can configure how long the attachments will be accessible by changing the token expiration timer. After that amount of seconds the token will expire, but you can always get a new attachment url with an active token.
+
 [source, bash]
 ----
-SECRET_KEY: "taiga-back-secret-key"
+ATTACHMENTS_MAX_AGE=360  # token expiration date (in seconds)
 ----
 
-`TAIGA_SECRET_KEY` or `SECRET_KEY` is the secret key of Taiga. Should be the same as this var in `taiga-back`, `taiga-events` and `taiga-protected`.
-`TAIGA_URL` in front service is where this Taiga instance should be served. It should be the same as `TAIGA_SITES_SCHEME://TAIGA_SITES_DOMAIN`.
-`TAIGA_WEBSOCKETS_URL` is used to connect to the events. This should have the same value as `wss://TAIGA_SITES_DOMAIN`, ie: wss://taiga.mycompany.com.
 
-.Session Settings
+.**Telemetry settings**
+
+Telemetry anonymous data is collected in order to learn about the use of Taiga and improve the platform based on real scenarios. You may want to enable this to help us shape future Taiga.
+
+[source, bash]
+----
+ENABLE_TELEMETRY=True
+----
+
+You can opt out by setting this variable to False. By default, it's True.
+
+
+[[customization]]
+=== Additional customization
+
+All these customization options are by default disabled and require you to edit `docker-compose.yml`.
+
+You should add the corresponding environment variables in the proper services with a valid value in order to enable them. Please, do not modify it unless you know what you’re doing.
+
+.**Session cookies in Django Admin**
 
 Taiga doesn't use session cookies in its API as it stateless. However, the Django Admin (`/admin/`) uses session cookie for authentication. By default, Taiga is configured to work behind HTTPS. If you're using HTTP (despite the strong recommendations against it), you'll need to configure the following environment variables so you can access the Admin:
 
-**Service: taiga-back**
+Service: `taiga-back`
 [source, bash]
 ----
 SESSION_COOKIE_SECURE: "False"
@@ -134,114 +170,24 @@ CSRF_COOKIE_SECURE: "False"
 
 More info about those variables can be found link:https://docs.djangoproject.com/en/3.1/ref/settings/#csrf-cookie-secure[here].
 
-.Email Settings
+.**Public registration**
+If you want to allow a public register, configure this variable to "True". By default it's "False". The value should be the same in `taiga-front` and `taiga-back`.
 
-By default, email is configured with the *console* backend, which means that the emails will be shown in the stdout. If you have an smtp service, uncomment the "Email settings" section in `docker-compose.yml` and configure those environment variables:
-
-**Service: taiga-back**
-[source, bash]
-----
-EMAIL_BACKEND: "django.core.mail.backends.smtp.EmailBackend"
-DEFAULT_FROM_EMAIL: "no-reply@mycompany.com"
-EMAIL_HOST: "smtp.host.mycompany.com"
-EMAIL_PORT: 587
-EMAIL_HOST_USER: "user"
-EMAIL_HOST_PASSWORD: "password"
-EMAIL_USE_TLS: "True"
-EMAIL_USE_SSL: "True"
-----
-
-Uncomment `EMAIL_BACKEND` variable, but do not modify unless you know what you're doing.
-
-.Telemetry Settings
-
-Telemetry anonymous data is collected in order to learn about the use of Taiga and improve the platform based on real scenarios.
-
-**Service: taiga-back**
-[source, bash]
-----
-ENABLE_TELEMETRY: "True"
-----
-
-You can opt out by setting this variable to "False". By default is "True".
-
-.Rabbit settings
-
-These variables are used to leave messages in the rabbitmq services. These variables should be the same as in `taiga-back`, `taiga-async`, `taiga-events`, `taiga-async-rabbitmq` and `taiga-events-rabbitmq`.
-
-**Service: taiga-back**
-[source, bash]
-----
-RABBITMQ_USER: taiga
-RABBITMQ_PASS: taiga
-----
-
-Two other variables `EVENTS_PUSH_BACKEND_URL` and `CELERY_BROKER_URL` can also be used to set the events push backend URL and celery broker URL.
-
-[source, bash]
-----
-EVENTS_PUSH_BACKEND_URL: "amqp://taiga:taiga@taiga-events-rabbitmq:5672/taiga"
-CELERY_BROKER_URL: "amqp://taiga:taiga@taiga-async-rabbitmq:5672/taiga"
-----
-
-**Service: taiga-events**
-[source, bash]
-----
-RABBITMQ_USER: taiga
-RABBITMQ_PASS: taiga
-----
-
-**Service: taiga-async-rabbitmq**
-[source, bash]
-----
-RABBITMQ_ERLANG_COOKIE: secret-erlang-cookie
-RABBITMQ_DEFAULT_USER: taiga
-RABBITMQ_DEFAULT_PASS: taiga
-RABBITMQ_DEFAULT_VHOST: taiga
-----
-
-**Service: taiga-events-rabbitmq**
-[source, bash]
-----
-RABBITMQ_ERLANG_COOKIE: secret-erlang-cookie
-RABBITMQ_DEFAULT_USER: taiga
-RABBITMQ_DEFAULT_PASS: taiga
-RABBITMQ_DEFAULT_VHOST: taiga
-----
-
-.Taiga protected settings
-
-**Service: taiga-protected**
-[source, bash]
-----
-MAX_AGE: 360
-----
-
-The attachments will be accesible with a token during MAX_AGE (in seconds). After that, the token will expire.
-
-=== Customisation
-
-All these features are disabled by default. You should add the corresponding environment variables with a proper value to enable them.
-
-.Registration Settings
-
-**Service: taiga-back**
+Service: `taiga-back`
 [source, bash]
 ----
 PUBLIC_REGISTER_ENABLED: "True"
 ----
 
-**Service: taiga-front**
+Service: `taiga-front`
 [source, bash]
 ----
 PUBLIC_REGISTER_ENABLED: "true"
 ----
 
-If you want to allow a public register, configure this variable to "True". By default is "False". Should be the same as this var in `taiga-front` and `taiga-back`.
-
 **Important**: Taiga (in its default configuration) disables both Gitlab or Github oauth buttons whenever the public registration option hasn't been activated. To be able to use Github/ Gitlab login/registration, make sure you have public registration activated on your Taiga instance.
 
-.Github settings
+.**GitHub OAuth login**
 
 Used for login with Github.
 
@@ -251,7 +197,7 @@ Set variables in docker-compose.yml:
 
 **Note** `ENABLE_GITHUB_AUTH` and `GITHUB_API_CLIENT_ID / GITHUB_CLIENT_ID` should have the same value in `taiga-back` and `taiga-front` services.
 
-**Service: taiga-back**
+Service: `taiga-back`
 [source, bash]
 ----
 ENABLE_GITHUB_AUTH: "True"
@@ -260,7 +206,7 @@ GITHUB_API_CLIENT_SECRET: "github-client-secret"
 PUBLIC_REGISTER_ENABLED: "True"
 ----
 
-**Service: taiga-front**
+Service: `taiga-front`
 [source, bash]
 ----
 ENABLE_GITHUB_AUTH: "true"
@@ -268,7 +214,7 @@ GITHUB_CLIENT_ID: "github-client-id"
 PUBLIC_REGISTER_ENABLED: "true"
 ----
 
-.Gitlab settings
+.**Gitlab OAuth login**
 
 Used for login with GitLab.
 
@@ -278,7 +224,7 @@ Set variables in docker-compose.yml:
 
 **Note** `ENABLE_GITLAB_AUTH`, `GITLAB_API_CLIENT_ID / GITLAB_CLIENT_ID` and `GITLAB_URL` should have the same value in `taiga-back` and `taiga-front` services.
 
-**Service: taiga-back**
+Service: `taiga-back`
 [source, bash]
 ----
 ENABLE_GITLAB_AUTH: "True"
@@ -288,7 +234,7 @@ GITLAB_URL: "gitlab-url"
 PUBLIC_REGISTER_ENABLED: "True"
 ----
 
-**Service: taiga-front**
+Service: `taiga-front`
 [source, bash]
 ----
 ENABLE_GITLAB_AUTH: "true"
@@ -297,25 +243,25 @@ GITLAB_URL: "gitlab-url"
 PUBLIC_REGISTER_ENABLED: "true"
 ----
 
-.Slack Settings
+.**Slack integration**
 
-**Service: taiga-back**
+Enable Slack integration in your Taiga instance. By default, it's "False". Should have the same value as this variable in `taiga-front` and `taiga-back`.
+
+Service: `taiga-back`
 [source, bash]
 ----
 ENABLE_SLACK: "True"
 ----
 
-**Service: taiga-front**
+Service: `taiga-front`
 [source, bash]
 ----
 ENABLE_SLACK: "true"
 ----
 
-Enable Slack integration in your Taiga instance. By default is "False". Should have the same value as this variable in `taiga-front` and `taiga-back`.
+.**GitHub importer**
 
-.Github importer
-
-**Service: taiga-back**
+Service: `taiga-back`
 [source, bash]
 ----
 ENABLE_GITHUB_IMPORTER: "True"
@@ -323,15 +269,15 @@ GITHUB_IMPORTER_CLIENT_ID: "client-id-from-github"
 GITHUB_IMPORTER_CLIENT_SECRET: "client-secret-from-github"
 ----
 
-**Service: taiga-front**
+Service: `taiga-front`
 [source, bash]
 ----
 ENABLE_GITHUB_IMPORTER: "true"
 ----
 
-.Jira importer
+.**Jira importer**
 
-**Service: taiga-back**
+Service: `taiga-back`
 [source, bash]
 ----
 ENABLE_JIRA_IMPORTER: "True"
@@ -340,15 +286,15 @@ JIRA_IMPORTER_CERT: "cert-from-jira"
 JIRA_IMPORTER_PUB_CERT: "pub-cert-from-jira"
 ----
 
-**Service: taiga-front**
+Service: `taiga-front`
 [source, bash]
 ----
 ENABLE_JIRA_IMPORTER: "true"
 ----
 
-.Trello importer
+.**Trello importer**
 
-**Service: taiga-back**
+Service: `taiga-back`
 [source, bash]
 ----
 ENABLE_TRELLO_IMPORTER: "True"
@@ -356,17 +302,19 @@ TRELLO_IMPORTER_API_KEY: "api-key-from-trello"
 TRELLO_IMPORTER_SECRET_KEY: "secret-key-from-trello"
 ----
 
-**Service: taiga-front**
+Service: `taiga-front`
 [source, bash]
 ----
 ENABLE_TRELLO_IMPORTER: "true"
 ----
 
-=== Advanced configuration and customisation
+=== Advanced configuration
 
-In an advanced configuration, you ignore the environment variables in `docker-compose.yml` or `docker-compose-inits.yml`.
+The advanced configuration **will ignore** the environment variables in `docker-compose.yml` or `docker-compose-inits.yml`. Skip this section if you're using env vars.
 
-.Map a `config.py` file
+It requires you to map the configuration files of `taiga-back` and `taiga-front` services to local files in order to unlock further configuration options.
+
+.**Map a `config.py` file **
 
 From https://github.com/kaleidos-ventures/taiga-back[taiga-back] download the file `settings/config.py.prod.example` and rename it:
 
@@ -394,7 +342,7 @@ FORCE_SCRIPT_NAME = ""
 ----
 
 Example to configure Taiga in **subpath**:
-[source, bash]
+[source, python]
 ----
 TAIGA_SITES_SCHEME = "https"
 TAIGA_SITES_DOMAIN = "taiga.mycompany.com"
@@ -405,7 +353,7 @@ Check as well the rest of the configuration if you need to enable some advanced 
 
 Map the file into `/taiga-back/settings/config.py`. Have in mind that you have to map it both in `docker-compose.yml` and `docker-compose-inits.yml`. You can check the `x-volumes` section in docker-compose.yml with an example.
 
-.Map a `conf.json` file
+.**Map a `conf.json` file**
 
 From https://github.com/kaleidos-ventures/taiga-front[taiga-front] download the file `dist/conf.example.json` and rename it:
 

--- a/setup-production.old.adoc
+++ b/setup-production.old.adoc
@@ -1,0 +1,488 @@
+= Install Taiga in Production [OLD]
+:toc: left
+:toclevels: 2
+:numbered:
+:source-highlighter: pygments
+:pygments-style: friendly
+:icons: font
+
+[[setup-prod-with-docker-old]]
+== Docker
+
+[WARNING]
+.This documentation is OUTDATED
+====
+Intended for older versions of Taiga (prior to ver. 6.6.0). It is maintained for archival purposes only.
+====
+
+[NOTE]
+====
+Updated information can be found link:setup-production.html#setup-prod-with-docker[here].
+If you are using this version, we strongly recommend to migrate to the link:upgrades-docker-migrate.html[new version].
+====
+
+This is the easiest and *recommended* way to run Taiga in production.
+This document explains how to deploy a full Taiga service for a production environment with `docker`.
+
+**Note** If you're updating from serving taiga6 in subdomain to subpath, check the specific instructions at the end of this tutorial.
+
+=== Requirements
+
+Prior to start the installation, ensure you have installed:
+
+* `docker`: version >= 17.09.0+
+* `docker-compose`: version >= 1.27.0+
+
+Additionally, it's necessary to have familiarity with Docker, docker-compose and Docker repositories.
+
+=== Get repository
+
+Clone link:https://github.com/kaleidos-ventures/taiga-docker[this repository].
+[source,bash]
+----
+$ cd taiga-docker/
+$ git checkout stable
+----
+
+=== Configuration with Environment Variables
+
+We've exposed the ** Basic configuration ** and the most commonly modified settings in Taiga to an `.env` file. We strongly recommend you to change it, or at least review its content, to avoid using the default values.
+
+Both `docker-compose.yml` and `docker-compose-inits.yml` will read from this file to populate their environment variables, so, initially you don't need to change them. Edit these files just in case you require to enable **Additional customization**, or an **Advanced configuration**.
+
+Refer to these sections for further information.
+
+=== Basic Configuration
+
+You will find basic **configuration variables** in the `.env` file. As stated before, we encourage you to edit these values, especially those affecting the security.
+
+.**Database settings**
+
+These vars are used to create the database for Taiga and connect to it.
+
+[source, bash]
+----
+POSTGRES_DB=taiga  # PostgreSQL database name
+POSTGRES_USER=taiga  # user to connect to PostgreSQL
+POSTGRES_PASSWORD=taiga  # database user's password
+----
+
+.**URLs settings**
+
+These vars set where your Taiga instance should be served, and the security protocols to use in the communication layer.
+[source, bash]
+----
+TAIGA_SCHEME=http  # serve Taiga using "http" or "https" (secured) connection
+TAIGA_DOMAIN=localhost:9000  # Taiga's base URL
+SUBPATH=""  # it'll be appended to the TAIGA_DOMAIN (use either "" or a "/subpath")
+WEBSOCKETS_SCHEME=ws  # events connection protocol (use either "ws" or "wss")
+----
+
+The default configuration assumes Taiga is being served in a **subdomain**. For example:
+[source, bash]
+----
+TAIGA_SCHEME=https
+TAIGA_DOMAIN=taiga.mycompany.com
+SUBPATH=""
+WEBSOCKETS_SCHEME=wss
+----
+
+If Taiga is being served in a **subpath**, instead of a subdomain, the configuration should be something like this:
+[source, bash]
+----
+TAIGA_SCHEME=https
+TAIGA_DOMAIN=mycompany.com
+SUBPATH="/taiga"
+WEBSOCKETS_SCHEME=wss
+----
+
+.**Secret Key settings**
+
+This variable allows you to set the secret key in Taiga, used in the cryptographic signing.
+
+[source, bash]
+----
+SECRET_KEY="taiga-secret-key"  # Please, change it to an unpredictable value!
+----
+
+.**Email settings**
+
+By default, emails will be printed in the standard output (`EMAIL_BACKEND=**console**`). If you have your own SMTP service, change it to `EMAIL_BACKEND=**smtp**` and configure the rest of these variables with the values supplied by your SMTP provider:
+
+[source, bash]
+----
+EMAIL_BACKEND=console  # use an SMTP server or display the emails in the console (either "smtp" or "console")
+EMAIL_HOST=smtp.host.example.com  # SMTP server address
+EMAIL_PORT=587   # default SMTP port
+EMAIL_HOST_USER=user  # user to connect the SMTP server
+EMAIL_HOST_PASSWORD=password  # SMTP user's password
+EMAIL_DEFAULT_FROM=changeme@example.com  # email address for the automated emails
+
+# EMAIL_USE_TLS/EMAIL_USE_SSL are mutually exclusive (only set one of those to True)
+EMAIL_USE_TLS=True  # use TLS (secure) connection with the SMTP server
+EMAIL_USE_SSL=False  # use implicit TLS (secure) connection with the SMTP server
+----
+
+.**Queue manager settings**
+These variables are used to leave messages in the rabbitmq services.
+
+[source, bash]
+----
+RABBITMQ_USER=taiga  # user to connect to RabbitMQ
+RABBITMQ_PASS=taiga  # RabbitMQ user's password
+RABBITMQ_VHOST=taiga  # RabbitMQ container name
+RABBITMQ_ERLANG_COOKIE=secret-erlang-cookie  # unique value shared by any connected instance of RabbitMQ
+----
+
+
+.**Attachments settings**
+
+You can configure how long the attachments will be accessible by changing the token expiration timer. After that amount of seconds the token will expire, but you can always get a new attachment url with an active token.
+
+[source, bash]
+----
+ATTACHMENTS_MAX_AGE=360  # token expiration date (in seconds)
+----
+
+
+.**Telemetry settings**
+
+Telemetry anonymous data is collected in order to learn about the use of Taiga and improve the platform based on real scenarios.
+
+[source, bash]
+----
+ENABLE_TELEMETRY=True
+----
+
+You can opt out by setting this variable to False. By default, it's True.
+
+
+=== Additional customization
+
+All these customization options are by default disabled and require you to edit `docker-compose.yml` and `docker-compose-inits.yml`.
+
+You should add the corresponding environment variables in the proper services with a valid value in order to enable them. Please, do not modify it unless you know what you’re doing.
+
+.**Session cookies in Django Admin**
+
+Taiga doesn't use session cookies in its API as it stateless. However, the Django Admin (`/admin/`) uses session cookie for authentication. By default, Taiga is configured to work behind HTTPS. If you're using HTTP (despite the strong recommendations against it), you'll need to configure the following environment variables so you can access the Admin:
+
+Service: `taiga-back`
+[source, bash]
+----
+SESSION_COOKIE_SECURE: "False"
+CSRF_COOKIE_SECURE: "False"
+----
+
+More info about those variables can be found link:https://docs.djangoproject.com/en/3.1/ref/settings/#csrf-cookie-secure[here].
+
+.**Public registration**
+If you want to allow a public register, configure this variable to "True". By default it's "False". The value should be the same in `taiga-front` and `taiga-back`.
+
+Service: `taiga-back`
+[source, bash]
+----
+PUBLIC_REGISTER_ENABLED: "True"
+----
+
+Service: `taiga-front`
+[source, bash]
+----
+PUBLIC_REGISTER_ENABLED: "true"
+----
+
+**Important**: Taiga (in its default configuration) disables both Gitlab or Github oauth buttons whenever the public registration option hasn't been activated. To be able to use Github/ Gitlab login/registration, make sure you have public registration activated on your Taiga instance.
+
+.**GitHub OAuth login**
+
+Used for login with Github.
+
+Follow the link:https://docs.github.com/en/developers/apps/building-oauth-apps/creating-an-oauth-app[documentation] in Github, when save application Github displays the ID and Secret.
+
+Set variables in docker-compose.yml:
+
+**Note** `ENABLE_GITHUB_AUTH` and `GITHUB_API_CLIENT_ID / GITHUB_CLIENT_ID` should have the same value in `taiga-back` and `taiga-front` services.
+
+Service: `taiga-back`
+[source, bash]
+----
+ENABLE_GITHUB_AUTH: "True"
+GITHUB_API_CLIENT_ID: "github-client-id"
+GITHUB_API_CLIENT_SECRET: "github-client-secret"
+PUBLIC_REGISTER_ENABLED: "True"
+----
+
+Service: `taiga-front`
+[source, bash]
+----
+ENABLE_GITHUB_AUTH: "true"
+GITHUB_CLIENT_ID: "github-client-id"
+PUBLIC_REGISTER_ENABLED: "true"
+----
+
+.**Gitlab OAuth login**
+
+Used for login with GitLab.
+
+Follow the link:https://docs.gitlab.com/ee/integration/oauth_provider.html[documentation] in Gitlab, when save application GitLab displays the ID and Secret.
+
+Set variables in docker-compose.yml:
+
+**Note** `ENABLE_GITLAB_AUTH`, `GITLAB_API_CLIENT_ID / GITLAB_CLIENT_ID` and `GITLAB_URL` should have the same value in `taiga-back` and `taiga-front` services.
+
+Service: `taiga-back`
+[source, bash]
+----
+ENABLE_GITLAB_AUTH: "True"
+GITLAB_API_CLIENT_ID: "gitlab-client-id"
+GITLAB_API_CLIENT_SECRET: "gitlab-client-secret"
+GITLAB_URL: "gitlab-url"
+PUBLIC_REGISTER_ENABLED: "True"
+----
+
+Service: `taiga-front`
+[source, bash]
+----
+ENABLE_GITLAB_AUTH: "true"
+GITLAB_CLIENT_ID: "gitlab-client-id"
+GITLAB_URL: "gitlab-url"
+PUBLIC_REGISTER_ENABLED: "true"
+----
+
+.**Slack integration**
+
+Enable Slack integration in your Taiga instance. By default, it's "False". Should have the same value as this variable in `taiga-front` and `taiga-back`.
+
+Service: `taiga-back`
+[source, bash]
+----
+ENABLE_SLACK: "True"
+----
+
+Service: `taiga-front`
+[source, bash]
+----
+ENABLE_SLACK: "true"
+----
+
+.**GitHub importer**
+
+Service: `taiga-back`
+[source, bash]
+----
+ENABLE_GITHUB_IMPORTER: "True"
+GITHUB_IMPORTER_CLIENT_ID: "client-id-from-github"
+GITHUB_IMPORTER_CLIENT_SECRET: "client-secret-from-github"
+----
+
+Service: `taiga-front`
+[source, bash]
+----
+ENABLE_GITHUB_IMPORTER: "true"
+----
+
+.**Jira importer**
+
+Service: `taiga-back`
+[source, bash]
+----
+ENABLE_JIRA_IMPORTER: "True"
+JIRA_IMPORTER_CONSUMER_KEY: "consumer-key-from-jira"
+JIRA_IMPORTER_CERT: "cert-from-jira"
+JIRA_IMPORTER_PUB_CERT: "pub-cert-from-jira"
+----
+
+Service: `taiga-front`
+[source, bash]
+----
+ENABLE_JIRA_IMPORTER: "true"
+----
+
+.**Trello importer**
+
+Service: `taiga-back`
+[source, bash]
+----
+ENABLE_TRELLO_IMPORTER: "True"
+TRELLO_IMPORTER_API_KEY: "api-key-from-trello"
+TRELLO_IMPORTER_SECRET_KEY: "secret-key-from-trello"
+----
+
+Service: `taiga-front`
+[source, bash]
+----
+ENABLE_TRELLO_IMPORTER: "true"
+----
+
+=== Advanced configuration
+
+The advanced configuration **will ignore** the environment variables in `docker-compose.yml` or `docker-compose-inits.yml`. Skip this section if you're using env vars.
+
+It requires you to map the configuration files of `taiga-back` and `taiga-front` services to local files in order to unlock further configuration options.
+
+.**Map a `config.py` file **
+
+From https://github.com/kaleidos-ventures/taiga-back[taiga-back] download the file `settings/config.py.prod.example` and rename it:
+
+[source, bash]
+----
+mv settings/config.py.prod.example settings/config.py
+----
+
+Edit `config.py` with your own configuration:
+
+- Taiga secret key: **it's important** to change it. It must have the same value as the secret key in `taiga-events` and `taiga-protected`
+- Taiga urls: configure where Taiga would be served using `TAIGA_URL`, `SITES` and `FORCE_SCRIPT_NAME` (see examples below)
+- Connection to PostgreSQL; check `DATABASES` section in the file
+- Connection to RabbitMQ for `taiga-events`; check "EVENTS" section in the file
+- Connection to RabbitMQ for `taiga-async`; check "TAIGA ASYNC" section in the file
+- Credentials for email; check "EMAIL" section in the file
+- Enable/disable anonymous telemetry; check "TELEMETRY" section in the file
+
+Example to configure Taiga in **subdomain**:
+[source, bash]
+----
+TAIGA_SITES_SCHEME = "https"
+TAIGA_SITES_DOMAIN = "taiga.mycompany.com"
+FORCE_SCRIPT_NAME = ""
+----
+
+Example to configure Taiga in **subpath**:
+[source, python]
+----
+TAIGA_SITES_SCHEME = "https"
+TAIGA_SITES_DOMAIN = "taiga.mycompany.com"
+FORCE_SCRIPT_NAME = "/taiga"
+----
+
+Check as well the rest of the configuration if you need to enable some advanced features.
+
+Map the file into `/taiga-back/settings/config.py`. Have in mind that you have to map it both in `docker-compose.yml` and `docker-compose-inits.yml`. You can check the `x-volumes` section in docker-compose.yml with an example.
+
+.**Map a `conf.json` file**
+
+From https://github.com/kaleidos-ventures/taiga-front[taiga-front] download the file `dist/conf.example.json` and rename it:
+
+[source,bash]
+----
+mv dist/conf.example.json dist/conf.json
+----
+
+Edit it with your own configuration:
+
+- Taiga urls: configure where Taiga would be served using `api`, `eventsUrl` and `baseHref` (see examples below)
+
+Example to configure Taiga in **subdomain**:
+[source, bash]
+----
+# conf.json
+{
+    "api": "https://taiga.mycompany.com/api/v1/",
+    "eventsUrl": "wss://taiga.mycompany.com/events",
+    "baseHref": "/",
+----
+
+Example to configure Taiga in **subpath**:
+[source, bash]
+----
+# conf.json
+{
+    "api": "https://mycompany.com/taiga/api/v1/",
+    "eventsUrl": "wss://mycompany.com/taiga/events",
+    "baseHref": "/taiga/",
+----
+
+Check as well the rest of the configuration if you need to enable some advanced features.
+
+Map the file into `/taiga-front/dist/config.py`.
+
+=== Configure an admin user
+
+```sh
+$ docker-compose up -d
+
+$ docker-compose -f docker-compose.yml -f docker-compose-inits.yml run --rm taiga-manage createsuperuser
+```
+
+=== Up and running
+
+Once everything has been installed, launch all the services and check the result:
+
+[source,bash]
+----
+$ docker-compose up -d
+----
+
+=== Configure the proxy
+
+Your host configuration needs to make a proxy to `http://localhost:9000`.
+
+If Taiga is being served in a **subdomain**:
+[source,bash]
+----
+server {
+  server_name taiga.mycompany.com;
+
+  location / {
+    proxy_set_header Host $http_host;
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Scheme $scheme;
+    proxy_set_header X-Forwarded-Proto $scheme;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_redirect off;
+    proxy_pass http://localhost:9000/;
+  }
+
+  # Events
+  location /events {
+      proxy_pass http://localhost:9000/events;
+      proxy_http_version 1.1;
+      proxy_set_header Upgrade $http_upgrade;
+      proxy_set_header Connection "upgrade";
+      proxy_set_header Host $host;
+      proxy_connect_timeout 7d;
+      proxy_send_timeout 7d;
+      proxy_read_timeout 7d;
+  }
+
+  # TLS: Configure your TLS following the best practices inside your company
+  # Logs and other configurations
+}
+----
+
+If Taiga is being served in a **subpath** instead of a subdomain, the configuration should be something like:
+[source,bash]
+----
+server {
+  server_name mycompany.com;
+
+  location /taiga/ {
+    proxy_set_header Host $http_host;
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Scheme $scheme;
+    proxy_set_header X-Forwarded-Proto $scheme;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_redirect off;
+    proxy_pass http://localhost:9000/;
+  }
+
+  # Events
+  location /taiga/events {
+      proxy_pass http://localhost:9000/events;
+      proxy_http_version 1.1;
+      proxy_set_header Upgrade $http_upgrade;
+      proxy_set_header Connection "upgrade";
+      proxy_set_header Host $host;
+      proxy_connect_timeout 7d;
+      proxy_send_timeout 7d;
+      proxy_read_timeout 7d;
+  }
+
+  # TLS: Configure your TLS following the best practices inside your company
+  # Logs and other configurations
+}
+----
+
+=== Change between subpath and subdomain
+
+If you're changing Taiga configuration from default subdomain (https://taiga.mycompany.com) to subpath (http://mycompany.com/subpath) or vice versa, on top of adjusting the configuration as said above, you should consider changing the TAIGA_SECRET_KEY so the refresh works properly for the end user.

--- a/upgrades-docker-migrate.adoc
+++ b/upgrades-docker-migrate.adoc
@@ -1,0 +1,60 @@
+= Migrate to new docker settings
+:toc: left
+:toclevels: 1
+:numbered:
+:source-highlighter: pygments
+:pygments-style: friendly
+
+While `taiga-docker` has been a pretty successful way for many people to have a Taiga self-hosted, the Taiga team receives a bunch of questions about the docker configuration. We have released a new `taiga-docker` version with the main settings based in an `.env` file. The main goal behind this change is to make it way easier to have a basic Taiga up and running.
+
+For those of you who already have a self-hosted Taiga running with docker, this tutorial will guide you through the steps of the migration.
+
+[[taigadckr-to-taigadckr]]
+== Summary
+
+If you are familiar with docker and docker compose, this is the sensible summary:
+
+- save the modifications made in the `docker-compose.yml` and `docker-compose-inits.yml` files
+- update the repository `taiga-docker`
+- add the configuration values to the `.env` file
+- add the link:setup-production.html#customization[customization values] to the `docker-compose.yml` file
+- launch all services again
+
+That's it!
+
+== Step by step
+
+If you are not so familiar with docker or git, these are the comprehensive steps.
+
+=== Get and save your current configurations
+
+Make sure to save all the modifications to the `docker-compose.yml` and `docker-compose-inits.yml` files. Tipically, you'll be using the file in the repository, so a `git diff` will show you all the modifications.
+
+If you have any other modification, trace them as well.
+
+=== Update the repository
+
+Download the new version with `git fetch && git reset --hard origin/main`. Make sure you have now an `.env` file.
+
+=== Add the configuration values to the `.env` file
+
+Open the `.env` file and fill the values with the ones you stored previously:
+
+- Taiga URL
+- Taiga secret key
+- Postgres connection
+- Email configuration
+- RabbitMQ configuration
+- Attachments' token expiration
+- Enable telemetry: we use this anonymous telemetry to improve Taiga. You may want to enable this to help us shape future Taiga.
+
+=== Add the customization values to the `docker-file.yml` file
+
+link:setup-production.html#customization[Customizations] are still in the `docker-compose.yml` file, for instance:
+
+- GitLat Auth
+- GitHub Importer
+
+=== Launch Taiga again
+
+Run `docker-compose up -d` (you may have a slightly different way for this command) and check every service is up and running.


### PR DESCRIPTION
![gif](https://media.giphy.com/media/jdO5221aQufi69T3rT/giphy.gif)

This PR updates the docker installation guide to reflect changes in this other [PR](https://github.com/kaleidos-ventures/taiga-docker/pull/104) 
Most important change: 
> Centralize most common env vars from docker-compose.yml to an .env file to abstract complexity
